### PR TITLE
Redesign backend to enable autocomplete for `tc.backend`

### DIFF
--- a/tensorcircuit/backends/__init__.py
+++ b/tensorcircuit/backends/__init__.py
@@ -1,4 +1,2 @@
-from . import abstract_backend
-
 # prerun to hack base abstract backend
 from .backend_factory import get_backend

--- a/tensorcircuit/backends/__init__.py
+++ b/tensorcircuit/backends/__init__.py
@@ -1,4 +1,5 @@
-from .abstract_backend import _more_methods_for_backend
+#from .abstract_backend import _more_methods_for_backend
+from . import abstract_backend
 
 # prerun to hack base abstract backend
 from .backend_factory import get_backend

--- a/tensorcircuit/backends/__init__.py
+++ b/tensorcircuit/backends/__init__.py
@@ -1,4 +1,4 @@
-#from .abstract_backend import _more_methods_for_backend
+# from .abstract_backend import _more_methods_for_backend
 from . import abstract_backend
 
 # prerun to hack base abstract backend

--- a/tensorcircuit/backends/__init__.py
+++ b/tensorcircuit/backends/__init__.py
@@ -1,4 +1,3 @@
-# from .abstract_backend import _more_methods_for_backend
 from . import abstract_backend
 
 # prerun to hack base abstract backend

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -7,16 +7,19 @@ Backend magic inherited from tensornetwork: abstract backend
 import inspect
 from functools import reduce, partial
 from operator import mul
+from tkinter import W
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
 try:  # old version tn compatiblity
+    old = True
     from tensornetwork.backends import base_backend
 
     tnbackend = base_backend.BaseBackend
 
 except ImportError:
+    old = False
     from tensornetwork.backends import abstract_backend
 
     tnbackend = abstract_backend.AbstractBackend
@@ -26,7 +29,7 @@ from ..utils import return_partial
 Tensor = Any
 
 
-def _more_methods_for_backend(tnbackend: Any) -> None:
+class ExtendedBackend():
     """
     Add tensorcircuit specific backend methods, especially with their docstrings.
     """
@@ -1633,11 +1636,25 @@ def _more_methods_for_backend(tnbackend: Any) -> None:
 
     __str__ = __repr__
 
-    r = inspect.stack()
-    d = r[0].frame.f_locals
-    for k, v in d.items():
-        if k != "r":
-            setattr(tnbackend, k, v)
+    '''
+    @classmethod
+    def _add_methods_for_backend(cls, tnbackend):
+        r = inspect.stack()
+        # r[0]: r, i, tnbackend
+        # r[1]: all defined methods, e.g. copy, expm..., including _add_method_for_backend
+        for i in range(len(r)):
+            print(i, r[i].frame.f_locals.keys())
+        d = r[1].frame.f_locals
+        for k, v in d.items():
+            if k != "_add_method_for_backend":
+                setattr(tnbackend, k, v)
+    '''
 
 
-_more_methods_for_backend(tnbackend)
+#ExtendedBackend._add_methods_for_backend(tnbackend)
+#
+#breakpoint()
+#if old:
+#    base_backend.BaseBackend = ExtendedBackend
+#else:
+#    abstract_backend.AbstractBackend = ExtendedBackend

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -4,32 +4,17 @@ Backend magic inherited from tensornetwork: abstract backend
 # pylint: disable=invalid-name
 # pylint: disable=unused-variable
 
-import inspect
 from functools import reduce, partial
 from operator import mul
-from tkinter import W
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-
-try:  # old version tn compatiblity
-    old = True
-    from tensornetwork.backends import base_backend
-
-    tnbackend = base_backend.BaseBackend
-
-except ImportError:
-    old = False
-    from tensornetwork.backends import abstract_backend
-
-    tnbackend = abstract_backend.AbstractBackend
-
 from ..utils import return_partial
 
 Tensor = Any
 
 
-class ExtendedBackend():
+class ExtendedBackend:
     """
     Add tensorcircuit specific backend methods, especially with their docstrings.
     """
@@ -1635,26 +1620,3 @@ class ExtendedBackend():
         return self.name + "_backend"  # type: ignore
 
     __str__ = __repr__
-
-    '''
-    @classmethod
-    def _add_methods_for_backend(cls, tnbackend):
-        r = inspect.stack()
-        # r[0]: r, i, tnbackend
-        # r[1]: all defined methods, e.g. copy, expm..., including _add_method_for_backend
-        for i in range(len(r)):
-            print(i, r[i].frame.f_locals.keys())
-        d = r[1].frame.f_locals
-        for k, v in d.items():
-            if k != "_add_method_for_backend":
-                setattr(tnbackend, k, v)
-    '''
-
-
-#ExtendedBackend._add_methods_for_backend(tnbackend)
-#
-#breakpoint()
-#if old:
-#    base_backend.BaseBackend = ExtendedBackend
-#else:
-#    abstract_backend.AbstractBackend = ExtendedBackend

--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy.sparse import coo_matrix
 import tensornetwork
 from tensornetwork.backends.jax import jax_backend
+from .abstract_backend import ExtendedBackend
 
 try:  # old version tn compatiblity
     from tensornetwork.backends import base_backend
@@ -172,7 +173,7 @@ tensornetwork.backends.jax.jax_backend.JaxBackend.qr = _qr_jax
 tensornetwork.backends.jax.jax_backend.JaxBackend.rq = _rq_jax
 
 
-class JaxBackend(jax_backend.JaxBackend):  # type: ignore
+class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
     """
     See the original backend API at `jax backend
     <https://github.com/google/TensorNetwork/blob/master/tensornetwork/backends/jax/jax_backend.py>`_

--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -13,16 +13,6 @@ import tensornetwork
 from tensornetwork.backends.jax import jax_backend
 from .abstract_backend import ExtendedBackend
 
-try:  # old version tn compatiblity
-    from tensornetwork.backends import base_backend
-
-    tnbackend = base_backend.BaseBackend
-
-except ImportError:
-    from tensornetwork.backends import abstract_backend
-
-    tnbackend = abstract_backend.AbstractBackend
-
 logger = logging.getLogger(__name__)
 
 
@@ -368,7 +358,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
     def argmin(self, a: Tensor, axis: int = 0) -> Tensor:
         return jnp.argmin(a, axis=axis)
 
-    def unique_with_counts(
+    def unique_with_counts(  # type: ignore
         self, a: Tensor, *, size: Optional[int] = None, fill_value: Optional[int] = None
     ) -> Tuple[Tensor, Tensor]:
         return jnp.unique(a, return_counts=True, size=size, fill_value=fill_value)  # type: ignore
@@ -396,7 +386,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
             return True
         return False
 
-    def solve(self, A: Tensor, b: Tensor, assume_a: str = "gen") -> Tensor:
+    def solve(self, A: Tensor, b: Tensor, assume_a: str = "gen") -> Tensor:  # type: ignore
         return jsp.linalg.solve(A, b, assume_a)
 
     def tree_map(self, f: Callable[..., Any], *pytrees: Any) -> Any:

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -14,16 +14,6 @@ from scipy.sparse import coo_matrix, issparse
 from tensornetwork.backends.numpy import numpy_backend
 from .abstract_backend import ExtendedBackend
 
-try:  # old version tn compatiblity
-    from tensornetwork.backends import base_backend
-
-    tnbackend = base_backend.BaseBackend
-
-except ImportError:
-    from tensornetwork.backends import abstract_backend
-
-    tnbackend = abstract_backend.AbstractBackend
-
 logger = logging.getLogger(__name__)
 
 dtypestr: str
@@ -228,7 +218,7 @@ class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
     def left_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return np.left_shift(x, y)
 
-    def solve(self, A: Tensor, b: Tensor, assume_a: str = "gen") -> Tensor:
+    def solve(self, A: Tensor, b: Tensor, assume_a: str = "gen") -> Tensor:  # type: ignore
         # gen, sym, her, pos
         # https://stackoverflow.com/questions/44672029/difference-between-numpy-linalg-solve-and-numpy-linalg-lu-solve/44710451
         return solve(A, b, assume_a)

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -12,6 +12,7 @@ from scipy.linalg import expm, solve
 from scipy.special import softmax, expit
 from scipy.sparse import coo_matrix, issparse
 from tensornetwork.backends.numpy import numpy_backend
+from .abstract_backend import ExtendedBackend
 
 try:  # old version tn compatiblity
     from tensornetwork.backends import base_backend
@@ -22,7 +23,6 @@ except ImportError:
     from tensornetwork.backends import abstract_backend
 
     tnbackend = abstract_backend.AbstractBackend
-
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ tensornetwork.backends.numpy.numpy_backend.NumPyBackend.convert_to_tensor = (
 )
 
 
-class NumpyBackend(numpy_backend.NumPyBackend):  # type: ignore
+class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
     """
     see the original backend API at `numpy backend
     <https://github.com/google/TensorNetwork/blob/master/tensornetwork/backends/numpy/numpy_backend.py>`_

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -64,13 +64,13 @@ class NumpyBackend(numpy_backend.NumPyBackend):  # type: ignore
         r = np.eye(N, M=M)
         return self.cast(r, dtype)
 
-    def ones(self, shape: Tuple[int, ...], dtype: Optional[str] = None) -> Tensor:
+    def ones(self, shape: Sequence[int], dtype: Optional[str] = None) -> Tensor:
         if dtype is None:
             dtype = dtypestr
         r = np.ones(shape)
         return self.cast(r, dtype)
 
-    def zeros(self, shape: Tuple[int, ...], dtype: Optional[str] = None) -> Tensor:
+    def zeros(self, shape: Sequence[int], dtype: Optional[str] = None) -> Tensor:
         if dtype is None:
             dtype = dtypestr
         r = np.zeros(shape)

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -10,6 +10,7 @@ from functools import reduce
 
 import tensornetwork
 from tensornetwork.backends.pytorch import pytorch_backend
+from .abstract_backend import ExtendedBackend
 
 try:  # old version tn compatiblity
     from tensornetwork.backends import base_backend
@@ -181,7 +182,7 @@ tensornetwork.backends.pytorch.pytorch_backend.PyTorchBackend.qr = _qr_torch
 tensornetwork.backends.pytorch.pytorch_backend.PyTorchBackend.rq = _rq_torch
 
 
-class PyTorchBackend(pytorch_backend.PyTorchBackend):  # type: ignore
+class PyTorchBackend(pytorch_backend.PyTorchBackend, ExtendedBackend):  # type: ignore
     """
     See the original backend API at `pytorch backend
     <https://github.com/google/TensorNetwork/blob/master/tensornetwork/backends/pytorch/pytorch_backend.py>`_

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -12,16 +12,6 @@ import tensornetwork
 from tensornetwork.backends.pytorch import pytorch_backend
 from .abstract_backend import ExtendedBackend
 
-try:  # old version tn compatiblity
-    from tensornetwork.backends import base_backend
-
-    tnbackend = base_backend.BaseBackend
-
-except ImportError:
-    from tensornetwork.backends import abstract_backend
-
-    tnbackend = abstract_backend.AbstractBackend
-
 dtypestr: str
 Tensor = Any
 pytree = Any

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional, Sequence, Tuple, Union
 from scipy.sparse import coo_matrix
 import tensornetwork
 from tensornetwork.backends.tensorflow import tensorflow_backend
+from .abstract_backend import ExtendedBackend
 
 try:  # old version tn compatiblity
     from tensornetwork.backends import base_backend
@@ -225,7 +226,7 @@ tensornetwork.backends.tensorflow.tensorflow_backend.TensorFlowBackend.qr = _qr_
 tensornetwork.backends.tensorflow.tensorflow_backend.TensorFlowBackend.rq = _rq_tf
 
 
-class TensorFlowBackend(tensorflow_backend.TensorFlowBackend):  # type: ignore
+class TensorFlowBackend(tensorflow_backend.TensorFlowBackend, ExtendedBackend):  # type: ignore
     """
     See the original backend API at `tensorflow backend
     <https://github.com/google/TensorNetwork/blob/master/tensornetwork/backends/tensorflow/tensorflow_backend.py>`_

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -12,16 +12,6 @@ import tensornetwork
 from tensornetwork.backends.tensorflow import tensorflow_backend
 from .abstract_backend import ExtendedBackend
 
-try:  # old version tn compatiblity
-    from tensornetwork.backends import base_backend
-
-    tnbackend = base_backend.BaseBackend
-
-except ImportError:
-    from tensornetwork.backends import abstract_backend
-
-    tnbackend = abstract_backend.AbstractBackend
-
 dtypestr: str
 Tensor = Any
 RGenerator = Any  # tf.random.Generator

--- a/tensorcircuit/circuit.py
+++ b/tensorcircuit/circuit.py
@@ -234,10 +234,10 @@ class Circuit(BaseCircuit):
             status < px,
             lambda: gates.x().tensor,  # type: ignore
             lambda: backend.cond(
-                status < px + py, # type: ignore
+                status < px + py,  # type: ignore
                 lambda: gates.y().tensor,  # type: ignore
                 lambda: backend.cond(
-                    status < px + py + pz, # type: ignore
+                    status < px + py + pz,  # type: ignore
                     lambda: gates.z().tensor,  # type: ignore
                     lambda: gates.i().tensor,  # type: ignore
                 ),
@@ -324,7 +324,7 @@ class Circuit(BaseCircuit):
         # speed is similar to ``unitary_kraus``
         def index2gate2(r: Tensor, kraus: Sequence[Tensor]) -> Tensor:
             # r is int type Tensor of shape []
-            return backend.switch(r, [lambda _=k: _ for k in kraus]) # type: ignore
+            return backend.switch(r, [lambda _=k: _ for k in kraus])  # type: ignore
 
         return self._unitary_kraus_template(
             kraus,

--- a/tensorcircuit/circuit.py
+++ b/tensorcircuit/circuit.py
@@ -234,10 +234,10 @@ class Circuit(BaseCircuit):
             status < px,
             lambda: gates.x().tensor,  # type: ignore
             lambda: backend.cond(
-                status < px + py,
+                status < px + py, # type: ignore
                 lambda: gates.y().tensor,  # type: ignore
                 lambda: backend.cond(
-                    status < px + py + pz,
+                    status < px + py + pz, # type: ignore
                     lambda: gates.z().tensor,  # type: ignore
                     lambda: gates.i().tensor,  # type: ignore
                 ),
@@ -324,7 +324,7 @@ class Circuit(BaseCircuit):
         # speed is similar to ``unitary_kraus``
         def index2gate2(r: Tensor, kraus: Sequence[Tensor]) -> Tensor:
             # r is int type Tensor of shape []
-            return backend.switch(r, [lambda _=k: _ for k in kraus])
+            return backend.switch(r, [lambda _=k: _ for k in kraus]) # type: ignore
 
         return self._unitary_kraus_template(
             kraus,

--- a/tensorcircuit/cons.py
+++ b/tensorcircuit/cons.py
@@ -15,7 +15,7 @@ import opt_einsum
 import tensornetwork as tn
 from tensornetwork.backend_contextmanager import get_default_backend
 
-# from .backends.numpy_backend import NumpyBackend
+from .backends.numpy_backend import NumpyBackend
 from .backends import get_backend  # type: ignore
 from .simplify import _multi_remove
 
@@ -26,7 +26,7 @@ thismodule = sys.modules[__name__]
 dtypestr = "complex64"
 rdtypestr = "float32"
 npdtype = np.complex64
-backend = get_backend("numpy")
+backend: NumpyBackend = get_backend("numpy")
 contractor = tn.contractors.auto
 # these above lines are just for mypy, it is not very good at evaluating runtime object
 

--- a/tensorcircuit/mpscircuit.py
+++ b/tensorcircuit/mpscircuit.py
@@ -664,7 +664,7 @@ class MPSCircuit(AbstractCircuit):
            |  |           ||
         i--A--B--j  -> i--XX--j
         """
-        result = backend.ones((1, 1, 1), dtype=npdtype)
+        result = backend.ones((1, 1, 1), dtype=dtypestr)
         for tensor in self._mps.tensors:
             result = backend.einsum("iaj,jbk->iabk", result, tensor)
             ni, na, nb, nk = result.shape


### PR DESCRIPTION
1. Add `NumpyBackend` type for backend
2. Change the `_more_methods_for_backend` method to a class named `ExtendedBackend` and then let numpy, tensorflow, jax and pytorch backend inherit it