### PR TITLE
Fix qiskit instruction translation bug

### DIFF
--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -872,7 +872,9 @@ class AbstractCircuit:
         self.__dict__.update(newc.__dict__)
         return self
 
-    def append(self, c: "AbstractCircuit") -> "AbstractCircuit":
+    def append(
+        self, c: "AbstractCircuit", indices: Optional[List[int]] = None
+    ) -> "AbstractCircuit":
         """
         append circuit ``c`` before
 
@@ -894,11 +896,21 @@ class AbstractCircuit:
 
         :param c: The other circuit to be appended
         :type c: BaseCircuit
+        :param indices: the qubit indices to which ``c`` is appended on
+        :type indices: List[int]
         :return: The composed circuit
         :rtype: BaseCircuit
         """
         qir1 = self.to_qir()
         qir2 = c.to_qir()
+        if indices is not None:
+            qir2_old = qir2
+            qir2 = []
+            for d in qir2_old:
+                # avoid modifying the original circuit
+                d = d.copy()
+                d["index"] = [indices[i] for i in d["index"]]
+                qir2.append(d)
         newc = type(self).from_qir(qir1 + qir2, self.circuit_param)
         self.__dict__.update(newc.__dict__)
         return self

--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -535,6 +535,23 @@ class AbstractCircuit:
         }
         self._extra_qir.append(d)
 
+    def barrier_instruction(self, *index: List[int]) -> None:
+        """
+        add a barrier instruction flag, no effect on numerical simulation
+
+        :param index: the corresponding qubits
+        :type index: List[int]
+        """
+        l = len(self._qir)
+        d = {
+            "index": index,
+            "name": "barrier",
+            "gatef": "barrier",
+            "instruction": True,
+            "pos": l,
+        }
+        self._extra_qir.append(d)
+
     def to_qiskit(self, enable_instruction: bool = False) -> Any:
         """
         Translate ``tc.Circuit`` to a qiskit QuantumCircuit object.
@@ -896,8 +913,9 @@ class AbstractCircuit:
 
         :param c: The other circuit to be appended
         :type c: BaseCircuit
-        :param indices: the qubit indices to which ``c`` is appended on
-        :type indices: List[int]
+        :param indices: the qubit indices to which ``c`` is appended on.
+            Defaults to None, which means plain concatenation.
+        :type indices: Optional[List[int]], optional
         :return: The composed circuit
         :rtype: BaseCircuit
         """

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -147,7 +147,7 @@ def qir2qiskit(
                 _get_float(parameters, "theta"),
                 _get_float(parameters, "phi"),
                 _get_float(parameters, "lbd"),
-                *index
+                *index,
             )
         elif gate_name == "cu":
             getattr(qiskit_circ, "cu")(
@@ -155,7 +155,7 @@ def qir2qiskit(
                 _get_float(parameters, "phi"),
                 _get_float(parameters, "lbd"),
                 0,  # gamma
-                *index
+                *index,
             )
         elif gate_name == "iswap":
             qiskit_circ.append(
@@ -197,6 +197,8 @@ def qir2qiskit(
             qiskit_circ.measure(index, index)
         elif gate_name == "reset":
             qiskit_circ.reset(index)
+        elif gate_name == "barrier":
+            qiskit_circ.barrier(index)
         else:  # r cr any gate
             gatem = np.reshape(
                 backend.numpy(gate_info["gatef"](**parameters).tensor),
@@ -348,13 +350,17 @@ def qiskit2tc(
             # logger.warning(
             #     "qiskit to tc translation currently doesn't support reset instruction, just skipping"
             # )
+        elif gate_name == "barrier":
+            tc_circuit.barrier_instruction(*idx)
         elif not hasattr(gate_info[0], "__array__"):
             # an instruction containing a lot of gates.
             # the condition is based on
             # https://github.com/Qiskit/qiskit-terra/blob/2f5944d60140ceb6e30d5b891e8ffec735247ce9/qiskit/circuit/gate.py#L43
             qiskit_circuit = gate_info[0].definition
             if qiskit_circuit is None:
-                # handles barrier
+                logger.warning(
+                    f"qiskit to tc translation doesn't support {gate_name} instruction, skipping"
+                )
                 continue
             c = Circuit.from_qiskit(qiskit_circuit)
             tc_circuit.append(c, idx)

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -198,7 +198,7 @@ def qir2qiskit(
         elif gate_name == "reset":
             qiskit_circ.reset(index)
         elif gate_name == "barrier":
-            qiskit_circ.barrier(index)
+            qiskit_circ.barrier(*index)
         else:  # r cr any gate
             gatem = np.reshape(
                 backend.numpy(gate_info["gatef"](**parameters).tensor),

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -795,6 +795,12 @@ def test_append_circuit(backend):
     c.prepend(c1)
     np.testing.assert_allclose(c.expectation_ps(z=[1]), -1.0)
 
+    c = tc.Circuit(2)
+    c1 = tc.Circuit(1)
+    c1.x(0)
+    c.append(c1, [1])
+    np.testing.assert_allclose(c.state(), [0, 1, 0, 0])
+
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
 def test_apply_mpo_gate(backend):
@@ -974,6 +980,10 @@ def test_qiskit2tc():
     qisc.swap(0, 1)
     qisc.iswap(0, 1)
     qisc.toffoli(0, 1, 2)
+    # test Instructions
+    qisc2 = QuantumCircuit(1)
+    qisc2.h(0)
+    qisc.compose(qisc2, qubits=[1], inplace=True, wrap=True)
     qisc.barrier(0, 1, 2)
     qisc.s(1)
     qisc.t(1)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1023,6 +1023,10 @@ def test_qiskit2tc():
     qis_unitary = np.reshape(qis_unitary, [2**n, 2**n])
     p_mat = perm_matrix(n)
     np.testing.assert_allclose(p_mat @ tc_unitary @ p_mat, qis_unitary, atol=1e-5)
+    qisc_from_tc = c.to_qiskit(enable_instruction=True)
+    qis_unitary2 = qi.Operator(qisc_from_tc)
+    qis_unitary2 = np.reshape(qis_unitary2, [2**n, 2**n])
+    np.testing.assert_allclose(qis_unitary2, qis_unitary, atol=1e-5)
 
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])


### PR DESCRIPTION
fix #95. When complex instructions (instructions with multiple gates/instructions inside) are met, convert it to tensorcircuit Circuit and then append the circuit.