### PR TITLE
Support converting parameterized Qiskit circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 - Auto unroll composite qiskit instructions when translating to tc circuit
 
+- Add `binding_parameters` argument for translating parameterized qiskit circuit to tc circuit
+
 - Add `keep_measure_order` bool option to `from_openqasm` methods so that the measure instruction order is kept by qiskit
 
 ### Fixed

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -82,8 +82,8 @@ We currently support transform ``tc.Circuit`` from and to Qiskit ``QuantumCircui
 Export to Qiskit (possible for further hardware experiment, compiling, and visualization): ``c.to_qiskit()``.
 
 Import from Qiskit: ``c = tc.Circuit.from_qiskit(QuantumCircuit, n)``.
-Parameterized Qiskit circuit is supported by passing the parameters to the ``from_qiskit`` function,
-similar to the ``assign_parameters`` function in Qiskit.
+Parameterized Qiskit circuit is supported by passing the parameters to the ``binding_parameters`` argument
+of the ``from_qiskit`` function, similar to the ``assign_parameters`` function in Qiskit.
 
 **Circuit Visualization:** 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -81,7 +81,9 @@ We currently support transform ``tc.Circuit`` from and to Qiskit ``QuantumCircui
 
 Export to Qiskit (possible for further hardware experiment, compiling, and visualization): ``c.to_qiskit()``.
 
-Import from Qiskit: ``c = tc.Circuit.from_qiskit(QuantumCircuit, n)``
+Import from Qiskit: ``c = tc.Circuit.from_qiskit(QuantumCircuit, n)``.
+Parameterized Qiskit circuit is supported by passing the parameters to the ``from_qiskit`` function,
+similar to the ``assign_parameters`` function in Qiskit.
 
 **Circuit Visualization:** 
 

--- a/requirements/requirements-extra.txt
+++ b/requirements/requirements-extra.txt
@@ -1,4 +1,5 @@
 # extra dependencies for ci
 qiskit
+qiskit-nature
 torch
 jupyter

--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -692,7 +692,7 @@ class AbstractCircuit:
         n: Optional[int] = None,
         inputs: Optional[List[float]] = None,
         circuit_params: Optional[Dict[str, Any]] = None,
-        binding_params: Optional[Union[Sequence, Dict]] = None,
+        binding_params: Optional[Union[Sequence[float], Dict[Any, float]]] = None,
     ) -> "AbstractCircuit":
         """
         Import Qiskit QuantumCircuit object as a ``tc.Circuit`` object.
@@ -712,12 +712,12 @@ class AbstractCircuit:
         :type n: int
         :param inputs: possible input wavefunction for ``tc.Circuit``, defaults to None
         :type inputs: Optional[List[float]], optional
-        :param circuit_params: circuit attributes such as the number of qubits
+        :param circuit_params: kwargs given in Circuit.__init__ construction function, default to None.
         :type circuit_params: Optional[Dict[str, Any]]
         :param binding_params: (variational) parameters for the circuit.
             Could be either a sequence or dictionary depending on the type of parameters in the Qiskit circuit.
             For ``ParameterVectorElement`` use sequence. For ``Parameter`` use dictionary
-        :type binding_params: Optional[Union[Sequence, Dict]]
+        :type binding_params: Optional[Union[Sequence[float], Dict[Any, float]]]
         :return: The same circuit but as tensorcircuit object
         :rtype: Circuit
         """

--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -692,6 +692,7 @@ class AbstractCircuit:
         n: Optional[int] = None,
         inputs: Optional[List[float]] = None,
         circuit_params: Optional[Dict[str, Any]] = None,
+        binding_params: Optional[Union[Sequence, Dict]] = None,
     ) -> "AbstractCircuit":
         """
         Import Qiskit QuantumCircuit object as a ``tc.Circuit`` object.
@@ -711,6 +712,12 @@ class AbstractCircuit:
         :type n: int
         :param inputs: possible input wavefunction for ``tc.Circuit``, defaults to None
         :type inputs: Optional[List[float]], optional
+        :param circuit_params: circuit attributes such as the number of qubits
+        :type circuit_params: Optional[Dict[str, Any]]
+        :param binding_params: (variational) parameters for the circuit.
+            Could be either a sequence or dictionary depending on the type of parameters in the Qiskit circuit.
+            For ``ParameterVectorElement`` use sequence. For ``Parameter`` use dictionary
+        :type binding_params: Optional[Union[Sequence, Dict]]
         :return: The same circuit but as tensorcircuit object
         :rtype: Circuit
         """
@@ -719,7 +726,7 @@ class AbstractCircuit:
         if n is None:
             n = qc.num_qubits
 
-        return qiskit2tc(qc.data, n, inputs, is_dm=cls.is_dm, circuit_params=circuit_params)  # type: ignore
+        return qiskit2tc(qc.data, n, inputs, is_dm=cls.is_dm, circuit_params=circuit_params, binding_params=binding_params)  # type: ignore
 
     def vis_tex(self, **kws: Any) -> str:
         """

--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -71,6 +71,7 @@ class AbstractCircuit:
     inputs: Tensor
     circuit_param: Dict[str, Any]
     is_mps: bool
+    is_dm: bool
 
     sgates = sgates
     vgates = vgates
@@ -726,7 +727,14 @@ class AbstractCircuit:
         if n is None:
             n = qc.num_qubits
 
-        return qiskit2tc(qc.data, n, inputs, is_dm=cls.is_dm, circuit_params=circuit_params, binding_params=binding_params)  # type: ignore
+        return qiskit2tc(  # type: ignore
+            qc.data,
+            n,
+            inputs,
+            is_dm=cls.is_dm,
+            circuit_params=circuit_params,
+            binding_params=binding_params,
+        )
 
     def vis_tex(self, **kws: Any) -> str:
         """

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -15,6 +15,9 @@ try:
     from qiskit.circuit.library import XXPlusYYGate
     import qiskit.quantum_info as qi
     from qiskit.extensions.exceptions import ExtensionError
+    from qiskit.circuit.quantumcircuitdata import CircuitInstruction
+    from qiskit.circuit.parametervector import ParameterVectorElement
+    from qiskit.circuit import Parameter, ParameterExpression
 except ImportError:
     logger.warning(
         "Please first ``pip install -U qiskit`` to enable related functionality in translation module"
@@ -219,11 +222,11 @@ def qir2qiskit(
     return qiskit_circ
 
 
-def _translate_qiskit_params(gate_info, binding_params):
+def _translate_qiskit_params(
+    gate_info: CircuitInstruction, binding_params: Any
+) -> List[float]:
     parameters = []
     for p in gate_info[0].params:
-        from qiskit.circuit.parametervector import ParameterVectorElement
-        from qiskit.circuit import Parameter, ParameterExpression
 
         if isinstance(p, ParameterVectorElement):
             parameters.append(binding_params[p.index])
@@ -266,12 +269,12 @@ def ctrl_str2ctrl_state(ctrl_str: str, nctrl: int) -> List[int]:
 
 
 def qiskit2tc(
-    qcdata: List[List[Any]],
+    qcdata: List[CircuitInstruction],
     n: int,
     inputs: Optional[List[float]] = None,
     is_dm: bool = False,
     circuit_params: Optional[Dict[str, Any]] = None,
-    binding_params: Optional[Union[Sequence, Dict]] = None,
+    binding_params: Optional[Union[Sequence[float], Dict[Any, float]]] = None,
 ) -> Any:
     r"""
     Generate a tensorcircuit circuit using the quantum circuit data in qiskit.
@@ -286,17 +289,17 @@ def qiskit2tc(
     h
 
     :param qcdata: Quantum circuit data from qiskit.
-    :type qcdata: List[List[Any]]
+    :type qcdata: List[CircuitInstruction]
     :param n: # of qubits
     :type n: int
     :param inputs: Input state of the circuit. Default is None.
     :type inputs: Optional[List[float]]
-    :param circuit_params: circuit attributes such as the number of qubits
+    :param circuit_params: kwargs given in Circuit.__init__ construction function, default to None.
     :type circuit_params: Optional[Dict[str, Any]]
     :param binding_params: (variational) parameters for the circuit.
         Could be either a sequence or dictionary depending on the type of parameters in the Qiskit circuit.
         For ``ParameterVectorElement`` use sequence. For ``Parameter`` use dictionary
-    :type binding_params: Optional[Union[Sequence, Dict]]
+    :type binding_params: Optional[Union[Sequence[float], Dict[Any, float]]]
     :return: A quantum circuit in tensorcircuit
     :rtype: Any
     """

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1029,6 +1029,50 @@ def test_qiskit2tc():
     np.testing.assert_allclose(qis_unitary2, qis_unitary, atol=1e-5)
 
 
+@pytest.mark.parametrize("backend", [lf("tfb"), lf("jaxb")])
+def test_qiskit2tc_parameterized(backend):
+    try:
+        from qiskit.circuit import QuantumCircuit, Parameter
+        from qiskit.quantum_info import Statevector, Operator
+        from qiskit.circuit.library import TwoLocal
+        from qiskit_nature.second_q.circuit.library import UCCSD
+        from qiskit_nature.second_q.mappers import ParityMapper, QubitConverter
+    except ImportError:
+        pytest.skip("qiskit or qiskit-nature is not installed")
+    from tensorcircuit.translation import perm_matrix
+
+    mapper = ParityMapper()
+    converter = QubitConverter(mapper=mapper, two_qubit_reduction=True)
+    ansatz1 = UCCSD(2, [1, 1], converter)
+    ansatz2 = TwoLocal(2, rotation_blocks="ry", entanglement_blocks="cz")
+    ansatz3 = QuantumCircuit(1)
+    ansatz3_param = Parameter("θ")
+    ansatz3.rx(ansatz3_param, 0)
+    ansatz_list = [ansatz1, ansatz2, ansatz3]
+    for ansatz in ansatz_list:
+        n = ansatz.num_qubits
+        if ansatz in [ansatz1, ansatz2]:
+            params = np.random.rand(ansatz.num_parameters)
+        else:
+            params = {ansatz3_param: 0.618}
+        qisc = ansatz.assign_parameters(params)
+        qiskit_unitary = Operator(qisc)
+        qiskit_unitary = np.reshape(qiskit_unitary, [2**n, 2**n])
+
+        @tc.backend.jit
+        def get_unitary(_params):
+            return tc.Circuit.from_qiskit(
+                ansatz, inputs=np.eye(2**n), binding_params=_params
+            ).state()
+
+        tc_unitary = get_unitary(params)
+        tc_unitary = np.reshape(tc_unitary, [2**n, 2**n])
+        p_mat = perm_matrix(n)
+        np.testing.assert_allclose(
+            p_mat @ tc_unitary @ p_mat, qiskit_unitary, atol=1e-5
+        )
+
+
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
 def test_batch_sample(backend):
     c = tc.Circuit(3)


### PR DESCRIPTION
Support converting parameterized Qiskit circuit. Can handle simple ParameterExpression such as `1.0 * theta` and will raise a ValueError if the expression is too complicated.