### PR TITLE
noisy circuit with circuit parameter

### DIFF
--- a/tensorcircuit/densitymatrix.py
+++ b/tensorcircuit/densitymatrix.py
@@ -75,10 +75,10 @@ class DMCircuit(BaseCircuit):
                 n = int(np.log(N) / np.log(2))
                 assert n == nqubits
                 inputs = backend.reshape(inputs, [2 for _ in range(n)])
-                inputs = Gate(inputs)
-                self._nodes = [inputs]
+                inputs_gate = Gate(inputs)
+                self._nodes = [inputs_gate]
                 self.coloring_nodes(self._nodes)
-                self._front = [inputs.get_edge(i) for i in range(n)]
+                self._front = [inputs_gate.get_edge(i) for i in range(n)]
                 self._double_nodes_front()
 
             elif mps_inputs is not None:
@@ -94,9 +94,9 @@ class DMCircuit(BaseCircuit):
                 dminputs = backend.convert_to_tensor(dminputs)
                 dminputs = backend.cast(dminputs, dtype=dtypestr)
                 dminputs = backend.reshape(dminputs, [2 for _ in range(2 * nqubits)])
-                dminputs = Gate(dminputs)
-                nodes = [dminputs]
-                self._front = [dminputs.get_edge(i) for i in range(2 * nqubits)]
+                dminputs_gate = Gate(dminputs)
+                nodes = [dminputs_gate]
+                self._front = [dminputs_gate.get_edge(i) for i in range(2 * nqubits)]
                 self._nodes = nodes
                 self.coloring_nodes(self._nodes)
 

--- a/tensorcircuit/noisemodel.py
+++ b/tensorcircuit/noisemodel.py
@@ -186,9 +186,9 @@ def circuit_with_noise(
     qir = c.to_qir()
     cnew: AbstractCircuit
     if isinstance(c, DMCircuit):
-        cnew = DMCircuit(c._nqubits)
+        cnew = DMCircuit(**c.circuit_param)
     else:
-        cnew = Circuit(c._nqubits)
+        cnew = Circuit(**c.circuit_param)
     cnew = apply_qir_with_noise(cnew, qir, noise_conf, status)
     return cnew
 


### PR DESCRIPTION
Allow converting circuits with parameters such as input density matrix to noisy circuits.
In the init method of `DMCircuit`, avoid converting the type of `inputs` and `dminputs`, sothat `circuit_params` is correctly recorded.