### PR TITLE
Added one-way translation from qir to cirq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 from tensorcircuit import __version__, __author__
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding = "utf-8") as fh:
     long_description = fh.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 from tensorcircuit import __version__, __author__
 
-with open("README.md", "r", encoding = "utf-8") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 

--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -622,6 +622,21 @@ class AbstractCircuit:
         }
         self._extra_qir.append(d)
 
+    def to_cirq(self, enable_instruction: bool = False) -> Any:
+        """
+        Translate ``tc.Circuit`` to a cirq circuit object.
+
+        :param enable_instruction: whether also export measurement and reset instructions
+        :type enable_instruction: bool, defaults to False
+        :return: A cirq circuit of this circuit.
+        """
+        from .translation import qir2cirq
+
+        qir = self.to_qir()
+        if enable_instruction is False:
+            return qir2cirq(qir, n=self._nqubits)
+        return qir2cirq(qir, n=self._nqubits, extra_qir=self._extra_qir)
+
     def to_qiskit(self, enable_instruction: bool = False) -> Any:
         """
         Translate ``tc.Circuit`` to a qiskit QuantumCircuit object.

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -151,30 +151,19 @@ def qir2cirq(
                 # when ISWAP theta is not specified, _get_float will return default value of 0.0 instead of 1.0
             else:
                 cmd.append(cirq.ISwapPowGate(exponent = _get_float(parameters, "theta")).on(*index))
-        # elif gate_name in ["exp", "exp1"]:
-        #     print(gate_info)
         elif gate_name in ["mpo", "multicontrol"]:
             gatem = np.reshape(
                     backend.numpy(gate_info["gatef"](**parameters).eval_matrix()),
                     [2 ** len(index), 2 ** len(index)],
                 )
             ci_name = gate_info["name"]
-            # qiskit_circ.unitary(qop, index[::-1], label=qis_name)
             cgate = CustomizedCirqGate(gatem, ci_name, len(index))
-            # cgate   = CustomizedCirqGate(gatem, gate_name, len(index))
             cmd.append(cgate.on(*index))
         else:
             # Add Customized Gate if there is no match
             gatem = np.reshape(gate_info["gate"].tensor,[2 ** len(index), 2 ** len(index)],
             )
-            # Note: unitary test is not working for some of the generated matrix, probably add tolerance test later
-            # if not cirq.is_unitary(gatem):
-            #     logger.warning(
-            #         "omit non unitary gate in tensorcircuit when transforming to cirq: %s"
-            #         % gate_name
-            #     )
-            #     cmd.append(cirq.identity_each(*index))
-            #     continue
+            # Note: unitary test is not working for some of the generated matrix, probably add tolerance unitary test later
             cgate = CustomizedCirqGate(gatem, gate_name, len(index))
             cmd.append(cgate.on(*index))
     cirq_circuit = cirq.Circuit(*cmd)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -857,11 +857,11 @@ def test_circuit_quoperator(backend):
     qo = c.quoperator()
     np.testing.assert_allclose(qo.eval_matrix(), c.matrix(), atol=1e-5)
 
+
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
 def test_qir2cirq(backend):
     try:
         import cirq
-        from tensorcircuit.translation import perm_matrix
     except ImportError:
         pytest.skip("cirq is not installed")
     n = 6
@@ -953,7 +953,7 @@ def test_qir2cirq(backend):
     cirq_unitary = cirq.unitary()
     cirq_unitary = np.reshape(cirq_unitary, [2**n, 2**n])
 
-    np.testing.assert_allclose(tc_unitary, cirq_unitary, atol = 1e-5)
+    np.testing.assert_allclose(tc_unitary, cirq_unitary, atol=1e-5)
 
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -869,17 +869,17 @@ def test_qir2cirq(backend):
     for i in range(n):
         c.H(i)
     zz = np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
-    # for i in range(n):
-    #     c.exp(
-    #         i,
-    #         (i + 1) % n,
-    #         theta=tc.array_to_tensor(np.random.uniform()),
-    #         unitary=tc.array_to_tensor(zz),
-    #         name="zz",
-    #     )
-    # c.exp1(
-    #     1, 3, theta=tc.array_to_tensor(0.0j), unitary=tc.array_to_tensor(zz), name="zz"
-    # )
+    for i in range(n):
+        c.exp(
+            i,
+            (i + 1) % n,
+            theta=tc.array_to_tensor(np.random.uniform()),
+            unitary=tc.array_to_tensor(zz),
+            name="zz",
+        )
+    c.exp1(
+        1, 3, theta=tc.array_to_tensor(0.0j), unitary=tc.array_to_tensor(zz), name="zz"
+    )
     c.fredkin(0, 1, 2)
     c.cswap(1, 2, 3)
     c.ccnot(1, 2, 3)
@@ -911,7 +911,7 @@ def test_qir2cirq(backend):
     c.ryy(1, 4, theta=-2.0)
     c.rzz(1, 3, theta=0.5)
     c.u(2, theta=0, lbd=4.6, phi=-0.3)
-    # c.cu(4, 1, theta=1.2)
+    c.cu(4, 1, theta=1.2)
     c.rx(1, theta=tc.array_to_tensor(np.random.uniform()))
     c.r(5, theta=tc.array_to_tensor(np.random.uniform()))
     c.cr(
@@ -932,20 +932,20 @@ def test_qir2cirq(backend):
 
     c.any(1, 3, unitary=tc.array_to_tensor(np.reshape(zz, [2, 2, 2, 2])))
 
-    # gate = tc.gates.multicontrol_gate(
-    #     tc.array_to_tensor(tc.gates._x_matrix), ctrl=[1, 0]
-    # )
-    # c.mpo(0, 1, 2, mpo=gate.copy())
-    # c.multicontrol(
-    #     0,
-    #     2,
-    #     4,
-    #     1,
-    #     5,
-    #     ctrl=[0, 1, 0],
-    #     unitary=tc.array_to_tensor(tc.gates._zz_matrix),
-    #     name="zz",
-    # )
+    gate = tc.gates.multicontrol_gate(
+        tc.array_to_tensor(tc.gates._x_matrix), ctrl=[1, 0]
+    )
+    c.mpo(0, 1, 2, mpo=gate.copy())
+    c.multicontrol(
+        0,
+        2,
+        4,
+        1,
+        5,
+        ctrl=[0, 1, 0],
+        unitary=tc.array_to_tensor(tc.gates._zz_matrix),
+        name="zz",
+    )
     tc_unitary = c.matrix()
     tc_unitary = np.reshape(tc_unitary, [2**n, 2**n])
 


### PR DESCRIPTION
The tested gates in test_qir2cirq are directly copyed from qir2qiskit, some of the component would be added in future
The test in test_qir2cirq is passed on my personal computer
Met problem of python version when developing, probably need to specify the version of python in guide for contributors (mine worked on python 3.9.13)
Added some todo in qir2cirq for future development
