### PR TITLE
[WIP] KaHyPar Initialization in TreeSA

### DIFF
--- a/examples/omeinsum_julia/README.md
+++ b/examples/omeinsum_julia/README.md
@@ -2,10 +2,13 @@
 
 This example introduces how to use OMEinsum, a julia-based einsum package, to contract a circuit in TensorCircuit.
 
-We provide two solutions 
+We provide two solutions:
 
 * use subprocess to call a stand-alone julia script (recommended)
 * use juliacall to integrate julia script into python (seems to be more elegant, but not recommended)
+
+We highly recommend use the first solution based on subprocess, not only due to its compatibility to julia multi-threading, but also because the experimental KaHyPar-based initialization is developed based on it.
+
 
 ## Subprocess solution (Recommended)
 
@@ -15,13 +18,19 @@ This solution calls a stand-alone julia script `omeinsum.jl` for tensor network 
 
 * Step 1: install julia, see https://julialang.org/download/. Please install julia >= 1.8.5, the 1.6.7 LTS version raises: `Error in python: free(): invalid pointer`
 * Step 2: add julia path to the PATH env variable so that we can find it
-* Step 3: install julia package `OMEinsum`, `ArgParse` and `JSON`, this example was tested with OMEinsum v0.7.2, ArgParse v1.1.4 and JSON v0.21.3. See https://docs.julialang.org/en/v1/stdlib/Pkg/ for more details on julia's package manager
+* Step 3: install julia package `OMEinsum`, `ArgParse`, `JSON` and `KaHyPar`, this example was tested with OMEinsum v0.7.2, ArgParse v1.1.4, JSON v0.21.3 and KaHyPar v0.3.0. See https://docs.julialang.org/en/v1/stdlib/Pkg/ for more details on julia's package manager
 
 ### How to run
 
 Run
 `JULIA_NUM_THREADS=N python omeinsum_contractor_subprocess.py`. The env variable `JULIA_NUM_THREADS=N` will be passed to the julia script, so that you can enjoy the accelaration brought by julia multi-threading.
 
+
+### KaHyPar initialization
+
+The choice of initial status plays an important role in simulated annealing.
+In a discussion with the author of OMEinsum https://github.com/TensorBFS/OMEinsumContractionOrders.jl/issues/35, we
+found that there was a way to run TreeSA with initialzier other than greedy or random. We demo how KaHyPar can be used to produce the initial status of simulated annealing. Although we haven't seen significant improvement by using KaHyPar initialization, we believe it is a interesting topic to explore.
 
 ## JuliaCall solution (Not Recommended)
 

--- a/examples/omeinsum_julia/omeinsum_contractor_juliacall.py
+++ b/examples/omeinsum_julia/omeinsum_contractor_juliacall.py
@@ -31,7 +31,7 @@ tc.set_backend("tensorflow")
 class OMEinsumTreeSAOptimizerJuliaCall(OMEinsumTreeSAOptimizer):
     def __init__(
         self,
-        sc_target: float = 20,
+        sc_target: int = 20,
         betas: Tuple[float, float, float] = (0.01, 0.01, 15),
         ntrials: int = 10,
         niters: int = 50,

--- a/examples/omeinsum_julia/omeinsum_contractor_juliacall.py
+++ b/examples/omeinsum_julia/omeinsum_contractor_juliacall.py
@@ -104,32 +104,37 @@ class OMEinsumTreeSAOptimizerJuliaCall(OMEinsumTreeSAOptimizer):
         return path
 
 
-# For more random circuits, please refer to
-# https://datadryad.org/stash/dataset/doi:10.5061/dryad.k6t1rj8
-c = tc.Circuit.from_qsim_file("circuit_n12_m14_s0_e0_pEFGH.qsim")
+if __name__ == "__main__":
+    # For more random circuits, please refer to
+    # https://datadryad.org/stash/dataset/doi:10.5061/dryad.k6t1rj8
+    c = tc.Circuit.from_qsim_file("circuit_n12_m14_s0_e0_pEFGH.qsim")
 
-opt = ctg.ReusableHyperOptimizer(
-    methods=["greedy", "kahypar"],
-    parallel=True,
-    minimize="flops",
-    max_repeats=1024,
-    progbar=False,
-)
-print("cotengra contractor")
-tc.set_contractor(
-    "custom", optimizer=opt, preprocessing=True, contraction_info=True, debug_level=2
-)
-c.expectation_ps(z=[0], reuse=False)
+    opt = ctg.ReusableHyperOptimizer(
+        methods=["greedy", "kahypar"],
+        parallel=True,
+        minimize="flops",
+        max_repeats=1024,
+        progbar=False,
+    )
+    print("cotengra contractor")
+    tc.set_contractor(
+        "custom",
+        optimizer=opt,
+        preprocessing=True,
+        contraction_info=True,
+        debug_level=2,
+    )
+    c.expectation_ps(z=[0], reuse=False)
 
-print("OMEinsum contractor")
-opt_treesa = OMEinsumTreeSAOptimizerJuliaCall(
-    sc_target=30, sc_weight=0.0, rw_weight=0.0
-)
-tc.set_contractor(
-    "custom",
-    optimizer=opt_treesa,
-    preprocessing=True,
-    contraction_info=True,
-    debug_level=2,
-)
-c.expectation_ps(z=[0], reuse=False)
+    print("OMEinsum contractor")
+    opt_treesa = OMEinsumTreeSAOptimizerJuliaCall(
+        sc_target=30, sc_weight=0.0, rw_weight=0.0
+    )
+    tc.set_contractor(
+        "custom",
+        optimizer=opt_treesa,
+        preprocessing=True,
+        contraction_info=True,
+        debug_level=2,
+    )
+    c.expectation_ps(z=[0], reuse=False)

--- a/examples/omeinsum_julia/omeinsum_treesa_optimizer.py
+++ b/examples/omeinsum_julia/omeinsum_treesa_optimizer.py
@@ -4,7 +4,7 @@ from typing import List, Set, Dict, Tuple
 class OMEinsumTreeSAOptimizer(object):
     def __init__(
         self,
-        sc_target: float = 20,
+        sc_target: int = 20,
         betas: Tuple[float, float, float] = (0.01, 0.01, 15),
         ntrials: int = 10,
         niters: int = 50,


### PR DESCRIPTION
This PR is based on a discussion with the author of OMEinsumContractionOrders.jl

https://github.com/TensorBFS/OMEinsumContractionOrders.jl/issues/35

However we can not see significant difference between the two methods when contracting a google random circuit (circuit_n53_m20_s0_e0_pABCDCDAB):
```
OMEinsum contractor with kahypar init
------ contraction cost summary ------
log10[FLOPs]:  19.432  log2[SIZE]:  53  log2[WRITE]:  61.214

OMEinsum contractor with default greedy init
------ contraction cost summary ------
log10[FLOPs]:  19.435  log2[SIZE]:  53  log2[WRITE]:  61.262
```

This is so far a WIP PR and more discussion may be necessary.