### PR TITLE
Enable qiskit/tensorcircuit translation with circuit initialization

### DIFF
--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -197,7 +197,10 @@ def qir2cirq(
 
 
 def qir2qiskit(
-    qir: List[Dict[str, Any]], n: int, extra_qir: Optional[List[Dict[str, Any]]] = None
+    qir: List[Dict[str, Any]],
+    n: int,
+    extra_qir: Optional[List[Dict[str, Any]]] = None,
+    initialization: Optional[Tensor] = None,
 ) -> Any:
     r"""
     Generate a qiskit quantum circuit using the quantum intermediate
@@ -220,6 +223,8 @@ def qir2qiskit(
     :param extra_qir: The extra quantum IR of tc circuit including measure and reset on hardware,
         defaults to None
     :type extra_qir: Optional[List[Dict[str, Any]]]
+    :param initialization: Circuit initial state in qiskit format
+    :type initialization: Optional[Tensor]
     :return: qiskit QuantumCircuit object
     :rtype: Any
     """
@@ -228,6 +233,8 @@ def qir2qiskit(
         qiskit_circ = QuantumCircuit(n, n)
     else:
         qiskit_circ = QuantumCircuit(n)
+    if initialization is not None:
+        qiskit_circ.initialize(initialization)
     for gate_info in qir:
         index = gate_info["index"]
         gate_name = str(gate_info["gatef"])
@@ -440,6 +447,8 @@ def qiskit2tc(
         circuit_params = {}
     if "nqubits" not in circuit_params:
         circuit_params["nqubits"] = n
+    if qcdata[0][0].name == "initialize" and "inputs" not in circuit_params:
+        circuit_params["inputs"] = perm_matrix(n) @ np.array(qcdata[0][0].params)
     if inputs is not None:
         circuit_params["inputs"] = inputs
 
@@ -532,6 +541,9 @@ def qiskit2tc(
             # )
         elif gate_name == "barrier":
             tc_circuit.barrier_instruction(*idx)
+        elif gate_name == "initialize":
+            # already taken care of when initializing
+            continue
         elif not hasattr(gate_info[0], "__array__"):
             # an instruction containing a lot of gates.
             # the condition is based on

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1203,14 +1203,18 @@ def test_qiskit_vs_tc_intialization(backend):
     state = qi.Statevector(qis_c)
     qis_c = QuantumCircuit(n)
     qis_c.initialize(state)
+    qis_c.cnot(1, 2)
     c = tc.Circuit.from_qiskit(qis_c)
     c2 = tc.Circuit(n)
     c2.h(0)
     c2.cnot(0, 1)
     c2.y(2)
+    c2.cnot(1, 2)
     np.testing.assert_allclose(c.state(), c2.state(), atol=1e-8)
     np.testing.assert_allclose(
-        qi.Statevector(c.to_qiskit(enable_inputs=True)), state, atol=1e-8
+        qi.Statevector(c.to_qiskit(enable_inputs=True)),
+        qi.Statevector(qis_c),
+        atol=1e-8,
     )
 
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1187,6 +1187,34 @@ def test_qiskit2tc_parameterized(backend):
 
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
+def test_qiskit_vs_tc_intialization(backend):
+    try:
+        from qiskit import QuantumCircuit
+        import qiskit.quantum_info as qi
+    except ImportError:
+        pytest.skip("qiskit is not installed")
+
+    n = 3
+
+    qis_c = QuantumCircuit(n)
+    qis_c.h(0)
+    qis_c.cnot(0, 1)
+    qis_c.y(2)
+    state = qi.Statevector(qis_c)
+    qis_c = QuantumCircuit(n)
+    qis_c.initialize(state)
+    c = tc.Circuit.from_qiskit(qis_c)
+    c2 = tc.Circuit(n)
+    c2.h(0)
+    c2.cnot(0, 1)
+    c2.y(2)
+    np.testing.assert_allclose(c.state(), c2.state(), atol=1e-8)
+    np.testing.assert_allclose(
+        qi.Statevector(c.to_qiskit(enable_inputs=True)), state, atol=1e-8
+    )
+
+
+@pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
 def test_batch_sample(backend):
     c = tc.Circuit(3)
     c.H(0)


### PR DESCRIPTION
Enable qiskit/tensorcircuit translation with circuit initialization. The tricky point is that tensorcircuit input may not always be the actual circuit state. So an `enable_inputs` argument is added to `to_qiskit`.