### PR TITLE
Refactor noise model

### DIFF
--- a/tensorcircuit/abstractcircuit.py
+++ b/tensorcircuit/abstractcircuit.py
@@ -530,7 +530,7 @@ class AbstractCircuit:
             )
         return name
 
-    def gate_count(self, gate_list: Optional[Sequence[str]] = None) -> int:
+    def gate_count(self, gate_list: Optional[Union[str, Sequence[str]]] = None) -> int:
         """
         count the gate number of the circuit
 
@@ -545,7 +545,7 @@ class AbstractCircuit:
         >>> c.gate_count(["multicontrol", "toffoli"])
         2
 
-        :param gate_list: gate name list to be counted, defaults to None (counting all gates)
+        :param gate_list: gate name or gate name list to be counted, defaults to None (counting all gates)
         :type gate_list: Optional[Sequence[str]], optional
         :return: the total number of all gates or gates in the ``gate_list``
         :rtype: int
@@ -553,6 +553,8 @@ class AbstractCircuit:
         if gate_list is None:
             return len(self._qir)
         else:
+            if isinstance(gate_list, str):
+                gate_list = [gate_list]
             gate_list = [self.standardize_gate(g) for g in gate_list]
             c = 0
             for d in self._qir:

--- a/tensorcircuit/interfaces/scipy.py
+++ b/tensorcircuit/interfaces/scipy.py
@@ -80,8 +80,8 @@ def scipy_optimize_interface(
             scipy_vs = general_args_to_numpy(vs)
             gs = backend.reshape(gs, [-1])
             scipy_gs = general_args_to_numpy(gs)
-            scipy_vs = scipy_vs.astype(np.float64)
-            scipy_gs = scipy_gs.astype(np.float64)
+            scipy_vs = scipy_vs.real.astype(np.float64)
+            scipy_gs = scipy_gs.real.astype(np.float64)
             return scipy_vs, scipy_gs
 
         return scipy_vg
@@ -97,7 +97,7 @@ def scipy_optimize_interface(
             scipy_args = tuple(scipy_args)
         vs = fun(*scipy_args, **kws)
         scipy_vs = general_args_to_numpy(vs)
-        scipy_vs = scipy_vs.astype(np.float64)
+        scipy_vs = scipy_vs.real.astype(np.float64)
         return scipy_vs
 
     return scipy_v

--- a/tensorcircuit/noisemodel.py
+++ b/tensorcircuit/noisemodel.py
@@ -60,7 +60,6 @@ class NoiseConf:
         :type qubit: Optional[Sequence[Any]], optional
         """
         if gate_name == "readout":
-            # probably need to refactor readout error
             assert qubit is None
             self.readout_error = kraus  # type:ignore
             return
@@ -127,8 +126,7 @@ class NoiseConf:
         """
         count = 0
         for d in c.to_qir():
-            # pylint: disable-next=unused-variable
-            for _, condition, krauslist in self.nc:
+            for _, condition, _ in self.nc:
                 if condition(d):
                     count += 1
         return count

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1422,7 +1422,7 @@ def test_gate_count():
     c.ccnot(1, 2, 0)
     c.ccx(1, 2, 0)
     assert c.gate_count() == 8
-    assert c.gate_count(["h"]) == 2
+    assert c.gate_count("h") == 2
     assert c.gate_count(["ccnot"]) == 3
     assert c.gate_count(["rx", "multicontrol"]) == 2
     assert c.gate_count_by_condition(lambda qir: qir["index"] == (0,)) == 2

--- a/tests/test_noisemodel.py
+++ b/tests/test_noisemodel.py
@@ -134,24 +134,23 @@ def test_general_noisemodel(backend):
     noise_conf.add_noise("cnot", [error2], [[0, 1]])
     noise_conf.add_noise("readout", readout_error)
 
+    nmc = 100000
     # # test sample_expectation_ps
-    value1 = sample_expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf, nmc=10000)
-    value2 = c.sample_expectation_ps(x=[0, 1], noise_conf=noise_conf, nmc=10000)
+    value1 = sample_expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf, nmc=nmc)
+    value2 = c.sample_expectation_ps(x=[0, 1], noise_conf=noise_conf, nmc=nmc)
     value3 = dmc.sample_expectation_ps(x=[0, 1], noise_conf=noise_conf)
     np.testing.assert_allclose(value1, value2, atol=1e-2)
     np.testing.assert_allclose(value3, value2, atol=1e-2)
 
     # test expectation
-    value1 = expectation_noisfy(
-        c, (tc.gates.z(), [0]), noise_conf=noise_conf, nmc=10000
-    )
-    value2 = c.expectation((tc.gates.z(), [0]), noise_conf=noise_conf, nmc=10000)
+    value1 = expectation_noisfy(c, (tc.gates.z(), [0]), noise_conf=noise_conf, nmc=nmc)
+    value2 = c.expectation((tc.gates.z(), [0]), noise_conf=noise_conf, nmc=nmc)
     value3 = dmc.expectation((tc.gates.z(), [0]), noise_conf=noise_conf)
     np.testing.assert_allclose(value1, value2, atol=1e-2)
     np.testing.assert_allclose(value3, value2, atol=1e-2)
 
     # test expectation_ps
     # value = expectation_ps_noisfy(c, x=[0], noise_conf=noise_conf, nmc=10000)
-    value1 = c.expectation_ps(x=[0], noise_conf=noise_conf, nmc=10000)
+    value1 = c.expectation_ps(x=[0], noise_conf=noise_conf, nmc=nmc)
     value2 = dmc.expectation_ps(x=[0], noise_conf=noise_conf)
     np.testing.assert_allclose(value1, value2, atol=1e-2)

--- a/tests/test_noisemodel.py
+++ b/tests/test_noisemodel.py
@@ -66,22 +66,26 @@ def test_noisemodel(backend):
 
     # with readout_error
     value = sample_expectation_ps_noisfy(dmc, x=[0, 1], noise_conf=noise_conf)
-    np.testing.assert_allclose(value, -0.11, atol=1e-1)
+    np.testing.assert_allclose(value, -0.12, atol=1e-2)
 
     value = sample_expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf, nmc=100000)
-    np.testing.assert_allclose(value, -0.11, atol=1e-1)
+    np.testing.assert_allclose(value, -0.12, atol=1e-2)
 
-    # test composed channel
+    # test composed channel and general condition
     newerror = composedkraus(error1, error3)
     noise_conf1 = NoiseConf()
     noise_conf1.add_noise("rx", [newerror, error1], [[0], [1]])
     noise_conf1.add_noise("h", [error3, error1], [[0], [1]])
     noise_conf1.add_noise("x", [error3], [[0]])
-    noise_conf1.add_noise("cnot", [error2], [[0, 1]])
+
+    def condition(d):
+        return d["name"] == "cnot" and d["index"] == (0, 1)
+
+    noise_conf1.add_noise_by_condition(condition, error2)
     noise_conf1.add_noise("readout", readout_error)
 
-    # value = expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf1, nmc=10000)
-    # np.testing.assert_allclose(value, 0.09, atol=1e-1)
+    value = sample_expectation_ps_noisfy(dmc, x=[0, 1], noise_conf=noise_conf1)
+    np.testing.assert_allclose(value, -0.12, atol=1e-2)
 
     # test standardized gate
     newerror = composedkraus(error1, error3)
@@ -92,8 +96,10 @@ def test_noisemodel(backend):
     noise_conf2.add_noise("cx", [error2], [[0, 1]])
     noise_conf2.add_noise("readout", readout_error)
 
-    # value = expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf2, nmc=10000)
-    # np.testing.assert_allclose(value, 0.09, atol=1e-1)
+    value = sample_expectation_ps_noisfy(
+        c, x=[0, 1], noise_conf=noise_conf2, nmc=100000
+    )
+    np.testing.assert_allclose(value, -0.12, atol=1e-2)
 
 
 @pytest.mark.parametrize("backend", [lf("tfb"), lf("jaxb")])
@@ -132,8 +138,8 @@ def test_general_noisemodel(backend):
     value1 = sample_expectation_ps_noisfy(c, x=[0, 1], noise_conf=noise_conf, nmc=10000)
     value2 = c.sample_expectation_ps(x=[0, 1], noise_conf=noise_conf, nmc=10000)
     value3 = dmc.sample_expectation_ps(x=[0, 1], noise_conf=noise_conf)
-    np.testing.assert_allclose(value1, value2, atol=1e-1)
-    np.testing.assert_allclose(value3, value2, atol=1e-1)
+    np.testing.assert_allclose(value1, value2, atol=1e-2)
+    np.testing.assert_allclose(value3, value2, atol=1e-2)
 
     # test expectation
     value1 = expectation_noisfy(
@@ -141,11 +147,11 @@ def test_general_noisemodel(backend):
     )
     value2 = c.expectation((tc.gates.z(), [0]), noise_conf=noise_conf, nmc=10000)
     value3 = dmc.expectation((tc.gates.z(), [0]), noise_conf=noise_conf)
-    np.testing.assert_allclose(value1, value2, atol=1e-1)
-    np.testing.assert_allclose(value3, value2, atol=1e-1)
+    np.testing.assert_allclose(value1, value2, atol=1e-2)
+    np.testing.assert_allclose(value3, value2, atol=1e-2)
 
     # test expectation_ps
     # value = expectation_ps_noisfy(c, x=[0], noise_conf=noise_conf, nmc=10000)
     value1 = c.expectation_ps(x=[0], noise_conf=noise_conf, nmc=10000)
     value2 = dmc.expectation_ps(x=[0], noise_conf=noise_conf)
-    np.testing.assert_allclose(value1, value2, atol=1e-1)
+    np.testing.assert_allclose(value1, value2, atol=1e-2)


### PR DESCRIPTION
- Refactor noise model. 
    - Noise configurations are represented by tuples of description, condition and Kraus operators. 
    - Reatout error is treated separately. Compared to other noises, currently, the configuration of readout error is pretty simple. Probably it should be refactored to enable more functionalities such as different readout error for different qubits in the future. (edit: this is not  true)
    - Add `add_noise_by_condition`. 
    - Composing noise channels is disabled in `noisemodel.py`
    - Make the noise model tests more strict
- Enhance `gate_count`. Now support string inputs.
- Fix bug in the scipy interface to avoid complex to float warnings by numpy.