### PR TITLE
Update docs for ensemble and resolve issues found in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - Add methods in quantum module for translating ps list and xyz argument dict
 
+- add `templates.ensemble.bagging` module for bagging ensemble method
+
 ### Fixed
 
 - Circuit nosify in noise model now support all circuit attributs apart from qubit number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - Add methods in quantum module for translating ps list and xyz argument dict
 
-- add `templates.ensemble.bagging` module for bagging ensemble method
+- Add `templates.ensemble.bagging` module for bagging ensemble method
 
 ### Fixed
 

--- a/docs/source/api/compiler.rst
+++ b/docs/source/api/compiler.rst
@@ -1,4 +1,5 @@
 tensorcircuit.compiler
 ==================================================
 .. toctree::
+    compiler/composed_compiler.rst
     compiler/qiskit_compiler.rst

--- a/docs/source/api/compiler/composed_compiler.rst
+++ b/docs/source/api/compiler/composed_compiler.rst
@@ -1,0 +1,7 @@
+tensorcircuit.compiler.composed_compiler
+==================================================
+.. automodule:: tensorcircuit.compiler.composed_compiler
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/source/api/templates.rst
+++ b/docs/source/api/templates.rst
@@ -4,5 +4,6 @@ tensorcircuit.templates
     templates/blocks.rst
     templates/chems.rst
     templates/dataset.rst
+    templates/ensemble.rst
     templates/graphs.rst
     templates/measurements.rst

--- a/docs/source/api/templates/ensemble.rst
+++ b/docs/source/api/templates/ensemble.rst
@@ -1,0 +1,7 @@
+tensorcircuit.templates.ensemble
+==================================================
+.. automodule:: tensorcircuit.templates.ensemble
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -7,7 +7,6 @@ tensorcircuit
     ./api/basecircuit.rst
     ./api/channels.rst
     ./api/circuit.rst
-    ./api/cloud.rst
     ./api/compiler.rst
     ./api/cons.rst
     ./api/densitymatrix.rst


### PR DESCRIPTION
Updated docs and changelog for the addition of `tensorcircuit.template.ensemble`.
Issues found in docs:
- `/tensorcircuit/docs/source/api/cloud.rst` removed but entry still exist in `modules.rst`
- `/tensorcircuit/tensorcircuit/compiler/composed_compiler.py` exist, but there is no entry found in `/tensorcircuit/docs/source/api/compiler/` and `/tensorcircuit/docs/source/templates.rst`
These two issues were resolved on the second commit of this pr.