### PR TITLE
Resolve keras.engine not found error when tf/keras>=2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ examples/Unified AD model.ipynb
 docs/source/locale/zh/LC_MESSAGES/textbook.po
 docs/source/locale/zh/LC_MESSAGES/whitepapertoc_cn.po
 docs/source/locale/zh/LC_MESSAGES/textbooktoc.po
+test.qasm

--- a/docs/source/contribs/development_MacARM.md
+++ b/docs/source/contribs/development_MacARM.md
@@ -43,18 +43,44 @@ pip install [Package Name]
 
 ### Install Tensorflow (Optional)
 
-#### Install Tensorflow (Recommended Approach)
-
-❗️ Tensorflow with MacOS optimization would not function correctly in version 2.11.0 and before. Do not use this version of tensorflow if you intented to train any machine learning model.
-
-FYI: Error can occur when machine learning training or gpu related code is involved.
-
-⚠️ Tensorflow without macos optimization does not support Metal API and utilizing GPU (both intel chips and M-series chips) until at least tensorflow 2.11. Tensorflow-macos would fail when running `tc.backend.to_dense()`
+#### Install Tensorflow without MacOS optimization
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 conda create -n tc_venv python tensorflow=2.7
+```
+
+#### Verify Tensorflow Installation
+
+```
+import tensorflow as tf
+
+cifar = tf.keras.datasets.cifar100
+(x_train, y_train), (x_test, y_test) = cifar.load_data()
+model = tf.keras.applications.ResNet50(
+    include_top=True,
+    weights=None,
+    input_shape=(32, 32, 3),
+    classes=100,)
+
+loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+model.compile(optimizer="adam", loss=loss_fn, metrics=["accuracy"])
+model.fit(x_train, y_train, epochs=5, batch_size=64)
+```
+
+#### Install Tensorflow with MacOS optimization (Recommended)
+
+For tensorflow version 2.13 or later:
+```
+pip install tensorflow
+pip install tensorflow-metal
+```
+
+For tensorflow version 2.12 or earlier:
+```
+pip install tensorflow-macos
+pip install tensorflow-metal
 ```
 
 #### Verify Tensorflow Installation
@@ -81,7 +107,7 @@ model.fit(x_train, y_train, epochs=5, batch_size=64)
 pip install tensorcircuit
 ```
 
-Testing Platform (Tested Feb 2023)
+Testing Platform (Tested Jun 2023)
 
 - Platform 1:
   - MacOS Ventura 13.1 (Build version 22C65)
@@ -89,3 +115,6 @@ Testing Platform (Tested Feb 2023)
 - Platform 2:
   - MacOS Ventura 13.2 (Build version 22D49)
   - M1 Ultra (Virtual)
+- Platform 4:
+  - MacOS Sonoma 14.0 Beta 2 (Build version 23A5276g)
+  - M2 Max

--- a/tensorcircuit/templates/ensemble.py
+++ b/tensorcircuit/templates/ensemble.py
@@ -20,9 +20,7 @@ class bagging:  # A.K.A. voting
         self.need_confidence = True  # Help in reducing numbers of get_confidence runs
         self.permit_train = False
 
-    def append(
-        self, model: model_type, model_trained: bool
-    ) -> None:
+    def append(self, model: model_type, model_trained: bool) -> None:
         """
         Add model to the voting method
         """

--- a/tensorcircuit/templates/ensemble.py
+++ b/tensorcircuit/templates/ensemble.py
@@ -4,7 +4,6 @@ Useful utilities for ensemble
 
 from typing import Any, List, Optional
 import tensorflow as tf
-import keras
 import numpy as np
 
 NDArray = Any
@@ -56,7 +55,8 @@ class bagging:  # A.K.A. voting
         self.permit_train = True
         for i in range(self.count):
             if not self.model_trained[i]:
-                self.models[i].compile(**kwargs)
+                dic_kwargs = kwargs.copy()
+                self.models[i].compile(**dic_kwargs)
 
     def __get_confidence(self, model_index: int, input: NDArray) -> NDArray:
         """

--- a/tensorcircuit/templates/ensemble.py
+++ b/tensorcircuit/templates/ensemble.py
@@ -9,18 +9,19 @@ import numpy as np
 
 NDArray = Any
 kwargus = Any
+model_type = Any
 
 
 class bagging:  # A.K.A. voting
     def __init__(self) -> None:
-        self.models: List[keras.engine.functional.Functional] = []
+        self.models: List[model_type] = []
         self.model_trained: List[bool] = []
         self.count = 0
         self.need_confidence = True  # Help in reducing numbers of get_confidence runs
         self.permit_train = False
 
     def append(
-        self, model: keras.engine.functional.Functional, model_trained: bool
+        self, model: model_type, model_trained: bool
     ) -> None:
         """
         Add model to the voting method


### PR DESCRIPTION
When keras is greater (or equal) to 2.13, "AttributeError: module 'keras' has no attribute 'engine'" would occur. This is resolved in this pr.