### PR TITLE
support for r-qiskit gate to qiskit2c

### DIFF
--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -486,6 +486,13 @@ def qiskit2tc(
             getattr(tc_circuit, gate_name)(*idx, theta=parameters)
         elif gate_name in ["crx_o0", "cry_o0", "crz_o0"]:
             getattr(tc_circuit, "o" + gate_name[1:-3])(*idx, theta=parameters)
+        elif gate_name in ["r"]:
+            getattr(tc_circuit, "u")(
+                *idx,
+                theta=parameters[0],
+                phi=parameters[1] - np.pi / 2,
+                lbd=-parameters[1] + np.pi / 2,
+            )
         elif gate_name in ["u3", "u"]:
             getattr(tc_circuit, "u")(
                 *idx, theta=parameters[0], phi=parameters[1], lbd=parameters[2]

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1122,6 +1122,7 @@ def test_qiskit2tc():
     qisc.crz(np.random.uniform(), 2, 3, ctrl_state=0)
     qisc.crz(np.random.uniform(), 2, 3, ctrl_state=0)
     qisc.crz(np.random.uniform(), 2, 3, ctrl_state=0)
+    qisc.r(np.random.uniform(), np.random.uniform(), 1)
     qisc.unitary(exp_op, [1, 3])
     mcx_g = MCXGate(3, ctrl_state="010")
     qisc.append(mcx_g, [0, 1, 2, 3])


### PR DESCRIPTION
# Problem:
Currently, the `from_qiskit` function from the circuit objects (which calls `qiskit2c`) does not support the use of the [R-Gate ](https://qiskit.org/documentation/stubs/qiskit.circuit.library.RGate.html) from Qiskit, it would map it to an `any` gate. This can be problematic, for instance, when using an error channel addressed to this gate.

![Screenshot 2023-08-17 at 09 57 41](https://github.com/tencent-quantum-lab/tensorcircuit/assets/57567043/0d54dfff-a480-4601-9513-5088979997f7)


# Solution: 
Man map the `r` qiskit gate using the built-in gate [`u`](https://tensorcircuit.readthedocs.io/en/latest/api/gates.html#tensorcircuit.gates.u_gate) from tensor circuit, so it can be addressed with the noise channels.

![Screenshot 2023-08-17 at 10 00 39](https://github.com/tencent-quantum-lab/tensorcircuit/assets/57567043/214d22dd-b556-41b5-aafb-8714c3218b6c)

# Alternative:
TensorCircuit already has an [`r`gate](https://tensorcircuit.readthedocs.io/en/latest/api/gates.html#tensorcircuit.gates.r_gate), but this corresponds to a general single qubit gate. However, we can find the corresponding parameters coming from the R-qiskit gate so that R-qiskit gets mapped to r-tensorcircuit. This can be done finding the coefficients in the Pauli basis of the R-qiskit gate and solving the system of linear equations to find the angles.