### PR TITLE
fix(qir2cirq): add a parameter 'args' for '_circuit_diagram_info_'

### DIFF
--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -138,7 +138,9 @@ def qir2cirq(
         def _unitary_(self) -> Any:
             return self.uMatrix
 
-        def _circuit_diagram_info_(self) -> List[str]:
+        def _circuit_diagram_info_(
+            self, args: Optional[cirq.CircuitDiagramInfoArgs]
+        ) -> List[str]:
             return [self.name] * self.nqubit
 
     if extra_qir is not None and len(extra_qir) > 0:

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -139,7 +139,7 @@ def qir2cirq(
             return self.uMatrix
 
         def _circuit_diagram_info_(
-            self, args: Optional[cirq.CircuitDiagramInfoArgs]
+            self, *args: Optional[cirq.CircuitDiagramInfoArgs]
         ) -> List[str]:
             return [self.name] * self.nqubit
 


### PR DESCRIPTION
The original function `_circuit_diagram_info_` of `CustomizedCirqGate` lacks a parameter called `args`, which will cause `TypeError` when `cirq` invokes this function.