### PR TITLE
Access jax config without warning

### DIFF
--- a/tensorcircuit/cons.py
+++ b/tensorcircuit/cons.py
@@ -152,7 +152,7 @@ def set_dtype(dtype: Optional[str] = None, set_global: bool = True) -> Tuple[str
         raise ValueError(f"Unsupported data type: {dtype}")
 
     try:
-        from jax.config import config
+        from jax import config
     except ImportError:
         config = None  # type: ignore
 


### PR DESCRIPTION
- Fix the following deprecation warning
```text
DeprecationWarning: Accessing jax.config via the jax.config submodule is deprecated.
    from jax.config import config
```