### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -4,15 +4,16 @@ Backend magic inherited from tensornetwork: jax backend
 
 # pylint: disable=invalid-name
 
-from functools import partial
 import logging
 import warnings
+from functools import partial
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
-from scipy.sparse import coo_matrix
 import tensornetwork
+from scipy.sparse import coo_matrix
 from tensornetwork.backends.jax import jax_backend
+
 from .abstract_backend import ExtendedBackend
 
 logger = logging.getLogger(__name__)
@@ -196,8 +197,8 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
                 "Jax not installed, please switch to a different "
                 "backend or install Jax."
             )
-        from jax.experimental import sparse
         import jax.scipy
+        from jax.experimental import sparse
 
         try:
             import optax
@@ -419,7 +420,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
         return jnp.searchsorted(a, v, side)
 
     def tree_map(self, f: Callable[..., Any], *pytrees: Any) -> Any:
-        return libjax.tree_map(f, *pytrees)
+        return libjax.tree_util.tree_map(f, *pytrees)
 
     def tree_flatten(self, pytree: Any) -> Tuple[Any, Any]:
         return libjax.tree_util.tree_flatten(pytree)  # type: ignore
@@ -630,7 +631,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
         return isinstance(a, sparse.BCOO)  # type: ignore
 
     def device(self, a: Tensor) -> str:
-        dev = a.device()
+        dev = a.devices()
         return self._dev2str(dev)
 
     def device_move(self, a: Tensor, dev: Any) -> Tensor:
@@ -757,7 +758,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
                 gs = list(gs)
             for i, (j, g) in enumerate(zip(argnums_list, gs)):
                 if j not in vectorized_argnums:  # type: ignore
-                    gs[i] = libjax.tree_map(partial(jnp.sum, axis=0), g)
+                    gs[i] = libjax.tree_util.tree_map(partial(jnp.sum, axis=0), g)
             if isinstance(argnums, int):
                 gs = gs[0]
             else:

--- a/tensorcircuit/compiler/qiskit_compiler.py
+++ b/tensorcircuit/compiler/qiskit_compiler.py
@@ -2,8 +2,8 @@
 compiler interface via qiskit
 """
 
-from typing import Any, Dict, Optional
 import re
+from typing import Any, Dict, Optional
 
 from ..abstractcircuit import AbstractCircuit
 from ..circuit import Circuit
@@ -71,7 +71,7 @@ def _get_positional_logical_mapping_from_qiskit(qc: Any) -> Dict[int, int]:
     positional_logical_mapping = {}
     for inst in qc.data:
         if inst[0].name == "measure":
-            positional_logical_mapping[i] = inst[1][0].index
+            positional_logical_mapping[i] = qc.find_bit(inst[1][0]).index
             i += 1
 
     return positional_logical_mapping
@@ -95,16 +95,17 @@ def _get_logical_physical_mapping_from_qiskit(
     for inst in qc_after.data:
         if inst[0].name == "measure":
             if qc_before is None:
-                logical_q = inst[2][0].index
+                logical_q = qc_after.find_bit(inst[2][0]).index
             else:
                 for instb in qc_before.data:
                     if (
                         instb[0].name == "measure"
-                        and instb[2][0].index == inst[2][0].index
+                        and qc_before.find_bit(instb[2][0]).index
+                        == qc_after.find_bit(inst[2][0]).index
                     ):
-                        logical_q = instb[1][0].index
+                        logical_q = qc_before.find_bit(instb[1][0]).index
                         break
-            logical_physical_mapping[logical_q] = inst[1][0].index
+            logical_physical_mapping[logical_q] = qc_after.find_bit(inst[1][0]).index
     return logical_physical_mapping
 
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1078,6 +1078,7 @@ def test_qiskit2tc():
     try:
         import qiskit.quantum_info as qi
         from qiskit import QuantumCircuit
+        from qiskit.circuit.library import HamiltonianGate
         from qiskit.circuit.library.standard_gates import MCXGate, SwapGate
 
         from tensorcircuit.translation import perm_matrix
@@ -1090,7 +1091,8 @@ def test_qiskit2tc():
     zz = np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
     exp_op = qi.Operator(zz)
     for i in range(n):
-        qisc.hamiltonian(exp_op, time=np.random.uniform(), qubits=[i, (i + 1) % n])
+        gate = HamiltonianGate(exp_op, time=np.random.uniform())
+        qisc.append(gate, [i, (i + 1) % n])
     qisc.fredkin(1, 2, 3)
     qisc.cswap(1, 2, 3)
     qisc.swap(0, 1)


### PR DESCRIPTION
- Fixed following deprecation warnings:

```
tensorcircuit/translation.py:23
tensorcircuit/translation.py:23
tensorcircuit/translation.py:23
tensorcircuit/translation.py:23
tensorcircuit/translation.py:23
tensorcircuit/translation.py:23
  /home/kazuki_main/tensorcircuit/tensorcircuit/translation.py:23: DeprecationWarning: The qiskit.extensions module is deprecated since Qiskit 0.46.0. It will be removed in the Qiskit 1.0 release.
    from qiskit.extensions import UnitaryGate

tests/test_backends.py: 41 warnings
tests/test_channels.py: 1180 warnings
tests/test_interfaces.py: 510 warnings
tests/test_fgs.py: 4 warnings
tests/test_miscs.py: 12 warnings
tests/test_quantum.py: 36 warnings
tests/test_noisemodel.py: 8 warnings
tests/test_torchnn.py: 22 warnings
  /home/kazuki_main/tensorcircuit/tensorcircuit/backends/jax_backend.py:422: DeprecationWarning: jax.tree_map is deprecated: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
    return libjax.tree_map(f, *pytrees)

tests/test_backends.py::test_device_cpu_only[jaxb]
  /home/kazuki_main/tensorcircuit/tensorcircuit/backends/jax_backend.py:633: DeprecationWarning: arr.device() is deprecated. Use arr.devices() instead.
    dev = a.device()

tests/test_backends.py::test_vvag[jaxb]
tests/test_backends.py::test_vvag_dict[jaxb]
tests/test_circuit.py::test_dqas_type_circuit[jaxb]
tests/test_circuit.py::test_mixed_measurement_circuit[jaxb]
  /home/kazuki_main/tensorcircuit/tensorcircuit/backends/jax_backend.py:760: DeprecationWarning: jax.tree_map is deprecated: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
    gs[i] = libjax.tree_map(partial(jnp.sum, axis=0), g)

tests/test_circuit.py: 27 warnings
  /home/kazuki_main/tensorcircuit/tensorcircuit/translation.py:314: DeprecationWarning: The method ``qiskit.circuit.quantumcircuit.QuantumCircuit.hamiltonian()`` is deprecated as of qiskit 0.46.0. It will be removed in the 1.0.0 release. Instead, append a qiskit.circuit.library.HamiltonianGate to the circuit.
    qiskit_circ.hamiltonian(

tests/test_circuit.py::test_qiskit2tc
tests/test_circuit.py::test_qiskit2tc
tests/test_circuit.py::test_qiskit2tc
tests/test_circuit.py::test_qiskit2tc
tests/test_circuit.py::test_qiskit2tc
tests/test_circuit.py::test_qiskit2tc
  /home/kazuki_main/tensorcircuit/tests/test_circuit.py:1093: DeprecationWarning: The method ``qiskit.circuit.quantumcircuit.QuantumCircuit.hamiltonian()`` is deprecated as of qiskit 0.46.0. It will be removed in the 1.0.0 release. Instead, append a qiskit.circuit.library.HamiltonianGate to the circuit.
    qisc.hamiltonian(exp_op, time=np.random.uniform(), qubits=[i, (i + 1) % n])

tests/test_compiler.py: 22 warnings
  /home/kazuki_main/tensorcircuit/tensorcircuit/compiler/qiskit_compiler.py:103: DeprecationWarning: The property ``qiskit.circuit.bit.Bit.index`` is deprecated as of qiskit-terra 0.17. It will be removed in the Qiskit 1.0 release. Instead, use :meth:`~qiskit.circuit.quantumcircuit.QuantumCircuit.find_bit` to find all the containing registers within a circuit and the index of the bit within the circuit.
    and instb[2][0].index == inst[2][0].index

tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
  /home/kazuki_main/tensorcircuit/tensorcircuit/compiler/qiskit_compiler.py:105: DeprecationWarning: The property ``qiskit.circuit.bit.Bit.index`` is deprecated as of qiskit-terra 0.17. It will be removed in the Qiskit 1.0 release. Instead, use :meth:`~qiskit.circuit.quantumcircuit.QuantumCircuit.find_bit` to find all the containing registers within a circuit and the index of the bit within the circuit.
    logical_q = instb[1][0].index

tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
  /home/kazuki_main/tensorcircuit/tensorcircuit/compiler/qiskit_compiler.py:107: DeprecationWarning: The property ``qiskit.circuit.bit.Bit.index`` is deprecated as of qiskit-terra 0.17. It will be removed in the Qiskit 1.0 release. Instead, use :meth:`~qiskit.circuit.quantumcircuit.QuantumCircuit.find_bit` to find all the containing registers within a circuit and the index of the bit within the circuit.
    logical_physical_mapping[logical_q] = inst[1][0].index

tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_qsikit_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
tests/test_compiler.py::test_composed_compiler
  /home/kazuki_main/tensorcircuit/tensorcircuit/compiler/qiskit_compiler.py:74: DeprecationWarning: The property ``qiskit.circuit.bit.Bit.index`` is deprecated as of qiskit-terra 0.17. It will be removed in the Qiskit 1.0 release. Instead, use :meth:`~qiskit.circuit.quantumcircuit.QuantumCircuit.find_bit` to find all the containing registers within a circuit and the index of the bit within the circuit.
    positional_logical_mapping[i] = inst[1][0].index
```